### PR TITLE
remove musicbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ A list of projects hosted on Railway.
 ### Community starters
 A list of starters built by the community using the [Railway button](https://railway.app/button).
   
-- [24x7 Discord Musicbot](https://github.com/kb24x7/musicbot): This musicbot is made using ytdl-core-discord and Discord.js to run 24x7.
 - [Healthchecker](https://github.com/morgangallant/healthchecker): Healthchecker is a simple application to periodically send HTTP requests to an endpoint. If the endpoint returns an error, the application is marked as unhealthy and a notification is sent to Discord.
 - [Logs](https://github.com/morgangallant/logs): Logs is a service for maintaining personal logs by DM-ing a bot on Telegram. ([Demo](https://logs.morgangallant.com/))
 - [Scheduler](https://github.com/operandinc/scheduler): Scheduler is a simple job scheduler and CRON system, meant to be run as a singleton on Railway. Applications can schedule future jobs to be executed, and receive webhooks for firing CRON jobs.


### PR DESCRIPTION
https://support.discord.com/hc/en-us/articles/360035010351--Known-Issue-Music-Bots-Not-Playing-Music-From-Certain-Sources

Music bots are not a first class supported usecase for Railway. While they're not strictly banned (yet), we don't want to encourage hosting these on our platform