### PR TITLE
fix: Update jobs page link to careers page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A [blog](https://blog.railway.app/) where the team at Railway publish new posts 
 The [Railway button](https://docs.railway.com/guides/publish-and-share#deploy-on-railway-button) allows users to create links to Github repositories that can be cloned and deployed on Railway. Users can also configure the required plugins and environment variables.
 
 ### Careers
-A list of available jobs can be viewed on the [jobs page](https://www.notion.so/railwayapp/Jobs-bdc641c4b72947f2ab1e09bea5362363) hosted on Notion.
+A list of available jobs can be viewed on the [careers page](https://railway.com/careers).
   
 ### Discord
 The Railway team uses [Discord](https://discord.com/invite/xAm2w6g) to interact with users. It is also the best way to reach out to the team for help with any issues.


### PR DESCRIPTION
The notion page does not exist anymore, use the current Careers page

<img width="2000" height="1018" alt="image" src="https://github.com/user-attachments/assets/8cf008e0-6b6d-446d-9e7a-e3d4c45e17b6" />
